### PR TITLE
Show +/- matching examples if set on queries

### DIFF
--- a/plugins/staticcode/index.js
+++ b/plugins/staticcode/index.js
@@ -3,6 +3,22 @@ const Prism = require('prismjs');
 const parse = require('html-react-parser')
 
 module.exports = function (context, options) {
+  const padWithNewlines = (first, second) => {
+    const firstCount = first.split("\n").length;
+    const secondCount = second.split("\n").length;
+
+    var firstPadded = first.slice();
+    var secondPadded = second.slice();
+
+    if (firstCount > secondCount) {
+      secondPadded = secondPadded.concat("\n".repeat(firstCount - secondCount));
+    } else if (secondCount > firstCount) {
+      firstPadded = firstPadded.concat("\n".repeate(secondCount - firstCount));
+    }
+
+    return {first: firstPadded, second: secondPadded};
+  }
+
   const formatTraversal = (traversalAsString) => {
     const lines = traversalAsString.split('\n')
     lines.shift()
@@ -33,7 +49,26 @@ module.exports = function (context, options) {
         return result;
       });
 
-      content.qdb = withHighlightedTraversal;
+      const withHighlightedExamples = withHighlightedTraversal.map(e => {
+        const hasBothExamples = typeof e.positiveExample != 'undefined' && typeof e.negativeExample != 'undefined';
+        if (!hasBothExamples) {
+          return e;
+        }
+        var result = e;
+
+        var positiveExample = e.positiveExample.slice();
+        var negativeExample = e.negativeExample.slice();
+        if (hasBothExamples) {
+          const padded = padWithNewlines(positiveExample, negativeExample);
+          positiveExample = padded.first;
+          negativeExample = padded.second;
+        }
+        result.positiveExampleHighlighted = Prism.highlight(positiveExample, Prism.languages.javascript, 'javascript');
+        result.negativeExampleHighlighted = Prism.highlight(negativeExample, Prism.languages.javascript, 'javascript');
+        return result;
+      });
+
+      content.qdb = withHighlightedExamples;
 
       return content;
     },

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import "prismjs/themes/prism-tomorrow.css";
 import parse from 'html-react-parser';
 
-export default function Code({ highlightedCode, language }) {
+export default function Code({ highlightedCode }) {
   return (
     <div className="code">
       <pre>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -116,7 +116,7 @@ const Results = (props) => {
             {r.description}
           </p>
           CPGQL Query:
-          <Code language="js" highlightedCode={ r.highlightedTraversal } queryName={r.name} />
+          <Code language="js" highlightedCode={ r.highlightedTraversal } />
           <textarea readOnly className="hidden" value={ r.formattedTraversal } id={r.name} />
         </div>
         <div><span className="search-result-author">author: {r.author}</span></div>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -123,7 +123,7 @@ const MatchingExample = ({ positiveExample, negativeExample}) => {
   return (
     <div className="search-matching-examples">
       <div className="search-matching-examples-btns">
-        <Button className="btn-matching-examples" variant="contained" color="secondary" onClick={handleButtonClick}>{text}</Button>
+        <Button className="btn-matching-examples" variant="contained" onClick={handleButtonClick}>{text}</Button>
       </div>
       { !hidden &&
       <div className="search-matching-examples-code">

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -147,7 +147,7 @@ const MatchingExample = ({ positiveExample, negativeExample}) => {
 
 const Results = (props) => {
   const options = props.results.map(r => {
-    const hasMatchingExample = r.positiveExample || r.negativeExample;
+    const hasMatchingExample = r.positiveExampleHighlighted || r.negativeExampleHighlighted;
 
     return (
     <Card className="main-card mdc-elevation--z10" key={r.name} >
@@ -167,7 +167,10 @@ const Results = (props) => {
         <CopyButton textAreaId={r.name} />
 
         { hasMatchingExample &&
-          <MatchingExample positiveExample={ r.positiveExample } negativeExample={ r.negativeExample } />
+          <MatchingExample
+            positiveExample={ r.positiveExampleHighlighted }
+            negativeExample={ r.negativeExampleHighlighted }
+            />
         }
       </div>
     </Card>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -102,10 +102,53 @@ const CopyButton = ({ textAreaId }) => {
       </Button>
     </div>
   )
-}
+};
+
+const MatchingExample = ({ positiveExample, negativeExample}) => {
+  const buttonTextShow = "SHOW MATCHING EXAMPLES"
+  const buttonTextHide = "HIDE MATCHING EXAMPLES"
+
+  const [text, setText] = useState(buttonTextShow);
+  const [hidden, setHidden] = useState(true);
+
+  const handleButtonClick = (e) => {
+    setHidden(!hidden)
+    if (hidden) {
+      setText(buttonTextHide)
+    } else {
+      setText(buttonTextShow)
+    }
+  }
+
+  return (
+    <div className="search-matching-examples">
+      <div className="search-matching-examples-btns">
+        <Button className="btn-matching-examples" variant="contained" color="secondary" onClick={handleButtonClick}>{text}</Button>
+      </div>
+      { !hidden &&
+      <div className="search-matching-examples-code">
+        { positiveExample &&
+        <div className="search-matching-examples-code-first">
+          <span>the query matches:</span>
+          <Code language="java" highlightedCode={ positiveExample } />
+        </div>
+        }
+        { negativeExample &&
+          <div className="search-matching-examples-code-second">
+            <span>the query does not match:</span>
+            <Code language="java" highlightedCode={ negativeExample } />
+          </div>
+        }
+      </div>
+      }
+    </div>
+  )
+};
 
 const Results = (props) => {
   const options = props.results.map(r => {
+    const hasMatchingExample = r.positiveExample || r.negativeExample;
+
     return (
     <Card className="main-card mdc-elevation--z10" key={r.name} >
       <div className="search-result">
@@ -122,6 +165,10 @@ const Results = (props) => {
         <div><span className="search-result-author">author: {r.author}</span></div>
         <div><span className="search-result-tags">tags: {r.tags.join(',')}</span></div>
         <CopyButton textAreaId={r.name} />
+
+        { hasMatchingExample &&
+          <MatchingExample positiveExample={ r.positiveExample } negativeExample={ r.negativeExample } />
+        }
       </div>
     </Card>
   )})

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -161,3 +161,22 @@ a.search-filter-selected {
 .hidden {
   display: none;
 }
+
+div.search-matching-examples-btns {
+  margin-top: 2em;
+}
+
+div.search-matching-examples-code {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto;
+  margin-top: 1rem;
+}
+
+div.search-matching-examples-code-first {
+  padding: 1rem;
+}
+
+div.search-matching-examples-code-second {
+  padding: 1rem;
+}


### PR DESCRIPTION
very basic styling (improving after the QDB work has been done to support the examples in the first place)
elements only show if the querydb.json has the example properties set
implements button-toggle 
implements padding-adjustment (if there are two examples present, the one with the smaller number of newlines will be padded by the difference)
![padded](https://user-images.githubusercontent.com/497951/117313329-166c9e80-ae86-11eb-983b-e317f7043b17.png)
